### PR TITLE
Fix typos in security standards description

### DIFF
--- a/.cursor/src/Project Security Standards.mdc
+++ b/.cursor/src/Project Security Standards.mdc
@@ -1,5 +1,5 @@
 ---
-description: Reffer to this rule for how to create Authenication and securty for our project
+description: Refer to this rule for how to create Authentication and security for our project
 globs: 
 alwaysApply: false
 ---


### PR DESCRIPTION
## Summary
- correct spelling errors in Project Security Standards description

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d9995428832f96458a919882f39b